### PR TITLE
Support for DragAndDropTableViews that live in a nib/storyboard

### DIFF
--- a/DragAndDropTableView/DragAndDropTableView.m
+++ b/DragAndDropTableView/DragAndDropTableView.m
@@ -53,6 +53,16 @@ const static CGFloat kAutoScrollingThreshold = 60;
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        // Initialization code
+        [self setup];
+    }
+    return self;
+}
+
 -(void)setup
 {
     // register gesture recognizer


### PR DESCRIPTION
Hey there - just added an initWithCoder: so that the gesture recognizer will still get set up when your DragAndDropTableView is being deserialized from a nib.

Thanks for the project!
