### PR TITLE
fixed issue #3 and some other tweaks

### DIFF
--- a/DragAndDropTableView/DragAndDropTableView.h
+++ b/DragAndDropTableView/DragAndDropTableView.h
@@ -21,6 +21,13 @@
  @param section The section index which will be created if YES is returned.
  */
 -(BOOL)canCreateNewSection:(NSInteger)section;
+
+/**
+ Asks the datasource if cells should be animated from their old position after they are dragged. Default is YES.
+ 
+ @param tableView The table view providing this information.
+ */
+-(BOOL)tableViewShouldAnimateDraggedCells:(DragAndDropTableView *)tableView;
 @end
 
 @protocol DragAndDropTableViewDelegate <NSObject>


### PR DESCRIPTION
- fixed issue #3 (added some respondsToSelector checks for non-required methods such as tableView:heightForRowAtIndexPath: and numberOfSectionsInTableView:)
- minimumLegalDistance now takes contentInset.top into account
- now passing source indexPath to tableView:didEndDraggingCellToIndexPath:placeHolderView:
- added UIGestureRecognizerStateCancelled to gesture recognizer
- added tableViewShouldAnimateDraggedCells: method to DragAndDropTableViewDataSource, allowing a DragAndDropTableViewDataSource to opt out of animating the cells after they are dragged
- fixed unexpected non-editable cells issue (tableView:editingStyleForRowAtIndexPath: vs tableView:canEditRowAtIndexPath:)
